### PR TITLE
Add supports for recursively outputting generated array arguments

### DIFF
--- a/meringue-core/src/main/java/edu/neu/ccs/prl/meringue/Replayer.java
+++ b/meringue-core/src/main/java/edu/neu/ccs/prl/meringue/Replayer.java
@@ -6,9 +6,5 @@ public interface Replayer {
     void configure(String testClassName, String testMethodName, ClassLoader classLoader)
             throws ReflectiveOperationException;
 
-    Throwable execute(byte[] input);
-
-    default Throwable execute(byte[] input, File inputFile) {
-        return execute(input);
-    }
+    Throwable execute(byte[] input, File inputFile);
 }

--- a/meringue-jazzer-extension/src/main/java/edu/neu/ccs/prl/meringue/JazzerReplayer.java
+++ b/meringue-jazzer-extension/src/main/java/edu/neu/ccs/prl/meringue/JazzerReplayer.java
@@ -2,6 +2,8 @@ package edu.neu.ccs.prl.meringue;
 
 import com.code_intelligence.jazzer.replay.Replayer;
 
+import java.io.File;
+
 public final class JazzerReplayer implements edu.neu.ccs.prl.meringue.Replayer {
     @Override
     public void configure(String testClassName, String testMethodName, ClassLoader classLoader) {
@@ -10,7 +12,7 @@ public final class JazzerReplayer implements edu.neu.ccs.prl.meringue.Replayer {
     }
 
     @Override
-    public Throwable execute(byte[] input) {
+    public Throwable execute(byte[] input, File inputFile) {
         Replayer.executeFuzzTarget(JazzerTargetWrapper.class, input);
         return JazzerTargetWrapper.getLastThrown();
     }

--- a/meringue-zest-extension/src/main/java/edu/berkeley/cs/jqf/ZestForkMain.java
+++ b/meringue-zest-extension/src/main/java/edu/berkeley/cs/jqf/ZestForkMain.java
@@ -31,7 +31,7 @@ public final class ZestForkMain {
         run(testClass, testMethodName, guidance);
     }
 
-    static void run(Class<?> testClass, String testMethodName, Guidance guidance) throws MultipleFailureException {
+    public static void run(Class<?> testClass, String testMethodName, Guidance guidance) throws MultipleFailureException {
         Class<? extends Runner> runnerClass = getRunnerClass(testClass);
         if (runnerClass.equals(JQF.class)) {
             GuidedFuzzing.run(testClass, testMethodName, guidance, System.out);

--- a/meringue-zest-extension/src/main/java/edu/berkeley/cs/jqf/ZestFramework.java
+++ b/meringue-zest-extension/src/main/java/edu/berkeley/cs/jqf/ZestFramework.java
@@ -1,5 +1,6 @@
 package edu.berkeley.cs.jqf;
 
+import edu.berkeley.cs.jqf.replay.ZestReplayer;
 import edu.neu.ccs.prl.meringue.*;
 import janala.instrument.SnoopInstructionTransformer;
 import org.objectweb.asm.ClassVisitor;

--- a/meringue-zest-extension/src/main/java/edu/berkeley/cs/jqf/ZestReplayer.java
+++ b/meringue-zest-extension/src/main/java/edu/berkeley/cs/jqf/ZestReplayer.java
@@ -79,7 +79,6 @@ public final class ZestReplayer implements Replayer {
         public void observeGeneratedArgs(Object[] args) {
             if (argumentsDirectory != null) {
                 try {
-                    System.out.println(inputFile.getName());
                     observeGeneratedArgs(args, inputFile.getName(), 0);
                 } catch (IOException e) {
                     e.printStackTrace();

--- a/meringue-zest-extension/src/main/java/edu/berkeley/cs/jqf/ZestReplayer.java
+++ b/meringue-zest-extension/src/main/java/edu/berkeley/cs/jqf/ZestReplayer.java
@@ -12,7 +12,6 @@ import java.lang.reflect.Array;
 import java.util.function.Consumer;
 
 public final class ZestReplayer implements Replayer {
-    private static int maxRecurDepth = 5;
     private File argumentsDir;
     private Class<?> testClass;
     private String testMethodName;
@@ -87,7 +86,7 @@ public final class ZestReplayer implements Replayer {
         }
 
         private void observeGeneratedArgs(Object args, String fileName, int depth) throws IOException {
-            if (args.getClass().isArray() && depth < maxRecurDepth) {
+            if (args.getClass().isArray()) {
                 File file = new File(argumentsDirectory, fileName);
                 file.mkdirs();
                 for (int i = 0; i < Array.getLength(args); i++) {

--- a/meringue-zest-extension/src/main/java/edu/berkeley/cs/jqf/replay/ArgumentsWriter.java
+++ b/meringue-zest-extension/src/main/java/edu/berkeley/cs/jqf/replay/ArgumentsWriter.java
@@ -1,0 +1,8 @@
+package edu.berkeley.cs.jqf.replay;
+
+import java.io.File;
+import java.io.IOException;
+
+public interface ArgumentsWriter {
+    void write(Object[] args, File source) throws IOException;
+}

--- a/meringue-zest-extension/src/main/java/edu/berkeley/cs/jqf/replay/FileArgumentsWriter.java
+++ b/meringue-zest-extension/src/main/java/edu/berkeley/cs/jqf/replay/FileArgumentsWriter.java
@@ -1,0 +1,53 @@
+package edu.berkeley.cs.jqf.replay;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Arrays;
+
+public class FileArgumentsWriter implements ArgumentsWriter {
+    private final File outputDir;
+
+    public FileArgumentsWriter(File outputDir) throws IOException {
+        this.outputDir = outputDir;
+        if (!outputDir.isDirectory()) {
+            throw new IOException();
+        }
+    }
+
+    @Override
+    public void write(Object[] args, File source) throws IOException {
+        for (int i = 0; i < args.length; i++) {
+            File file = new File(outputDir, String.format("%s.%d", source.getName(), i));
+            try (PrintWriter out = new PrintWriter(file)) {
+                out.print(format(args[i]));
+            }
+        }
+    }
+
+    private String format(Object arg) {
+        if (arg == null) {
+            return "null";
+        } else if (arg instanceof byte[]) {
+            return Arrays.toString((byte[]) arg);
+        } else if (arg instanceof short[]) {
+            return Arrays.toString((short[]) arg);
+        } else if (arg instanceof int[]) {
+            return Arrays.toString((int[]) arg);
+        } else if (arg instanceof long[]) {
+            return Arrays.toString((long[]) arg);
+        } else if (arg instanceof char[]) {
+            return Arrays.toString((char[]) arg);
+        } else if (arg instanceof float[]) {
+            return Arrays.toString((float[]) arg);
+        } else if (arg instanceof double[]) {
+            return Arrays.toString((double[]) arg);
+        } else if (arg instanceof boolean[]) {
+            return Arrays.toString((boolean[]) arg);
+        } else if (arg instanceof Object[]) {
+            return Arrays.deepToString((Object[]) arg);
+        } else {
+            return arg.toString();
+        }
+    }
+}

--- a/meringue-zest-extension/src/main/java/edu/berkeley/cs/jqf/replay/ZestReplayer.java
+++ b/meringue-zest-extension/src/main/java/edu/berkeley/cs/jqf/replay/ZestReplayer.java
@@ -1,5 +1,6 @@
-package edu.berkeley.cs.jqf;
+package edu.berkeley.cs.jqf.replay;
 
+import edu.berkeley.cs.jqf.ZestForkMain;
 import edu.berkeley.cs.jqf.fuzz.guidance.Guidance;
 import edu.berkeley.cs.jqf.fuzz.guidance.GuidanceException;
 import edu.berkeley.cs.jqf.fuzz.guidance.Result;
@@ -7,20 +8,21 @@ import edu.berkeley.cs.jqf.instrument.tracing.events.TraceEvent;
 import edu.neu.ccs.prl.meringue.Replayer;
 import org.junit.runners.model.MultipleFailureException;
 
-import java.io.*;
-import java.lang.reflect.Array;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.function.Consumer;
 
 public final class ZestReplayer implements Replayer {
-    private File argumentsDir;
+    private final ArgumentsWriter writer;
     private Class<?> testClass;
     private String testMethodName;
 
-    public ZestReplayer() {
-        String argumentsDirPath = System.getProperty("zest.argumentsDir");
-        if (argumentsDirPath != null) {
-            argumentsDir = new File(argumentsDirPath);
-        }
+    public ZestReplayer() throws IOException {
+        String path = System.getProperty("zest.argumentsDir");
+        writer = path == null ? (a, f) -> {
+        } : new FileArgumentsWriter(new File(path));
     }
 
     @Override
@@ -34,13 +36,8 @@ public final class ZestReplayer implements Replayer {
     }
 
     @Override
-    public Throwable execute(byte[] input) {
-        return execute(input, null);
-    }
-
-    @Override
     public Throwable execute(byte[] input, File inputFile) {
-        ReplayGuidance guidance = new ReplayGuidance(input, inputFile, inputFile == null ? null : argumentsDir);
+        ReplayGuidance guidance = new ReplayGuidance(input, inputFile, writer);
         try {
             ZestForkMain.run(testClass, testMethodName, guidance);
         } catch (MultipleFailureException e) {
@@ -52,14 +49,14 @@ public final class ZestReplayer implements Replayer {
     private static final class ReplayGuidance implements Guidance {
         private final byte[] input;
         private final File inputFile;
-        private final File argumentsDirectory;
+        private final ArgumentsWriter writer;
         private boolean consumed = false;
         private Throwable error = null;
 
-        private ReplayGuidance(byte[] input, File inputFile, File argumentsDirectory) {
+        private ReplayGuidance(byte[] input, File inputFile, ArgumentsWriter writer) {
             this.input = input;
             this.inputFile = inputFile;
-            this.argumentsDirectory = argumentsDirectory;
+            this.writer = writer;
         }
 
         @Override
@@ -76,27 +73,10 @@ public final class ZestReplayer implements Replayer {
 
         @Override
         public void observeGeneratedArgs(Object[] args) {
-            if (argumentsDirectory != null) {
-                try {
-                    observeGeneratedArgs(args, inputFile.getName(), 0);
-                } catch (IOException e) {
-                    e.printStackTrace();
-                }
-            }
-        }
-
-        private void observeGeneratedArgs(Object args, String fileName, int depth) throws IOException {
-            if (args.getClass().isArray()) {
-                File file = new File(argumentsDirectory, fileName);
-                file.mkdirs();
-                for (int i = 0; i < Array.getLength(args); i++) {
-                    observeGeneratedArgs(Array.get(args, i), fileName + String.format("/%d", i), depth + 1);
-                }
-            } else {
-                File file = new File(argumentsDirectory, fileName);
-                try (PrintWriter out = new PrintWriter(file)) {
-                    out.print(args);
-                }
+            try {
+                writer.write(args, inputFile);
+            } catch (IOException e) {
+                e.printStackTrace();
             }
         }
 

--- a/meringue-zest-extension/src/test/java/edu/berkeley/cs/jqf/replay/FileArgumentsWriterTest.java
+++ b/meringue-zest-extension/src/test/java/edu/berkeley/cs/jqf/replay/FileArgumentsWriterTest.java
@@ -1,0 +1,97 @@
+package edu.berkeley.cs.jqf.replay;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.Objects;
+
+public class FileArgumentsWriterTest {
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    @Test
+    public void writeNullArgument() throws IOException {
+        Object argument = null;
+        String[] s = writeRead(new Object[]{argument});
+        Assert.assertArrayEquals(new String[]{"null"}, s);
+    }
+
+    @Test
+    public void writeStringArgument() throws IOException {
+        Object argument = "hello";
+        writeRead(new Object[]{argument});
+        String[] s = writeRead(new Object[]{argument});
+        Assert.assertArrayEquals(new String[]{"hello"}, s);
+    }
+
+    @Test
+    public void writeStringArrayArgument() throws IOException {
+        Object argument = new String[]{"hello", "world"};
+        writeRead(new Object[]{argument});
+        String[] s = writeRead(new Object[]{argument});
+        Assert.assertArrayEquals(new String[]{"[hello, world]"}, s);
+    }
+
+    @Test
+    public void writeStringArrayNullElementArgument() throws IOException {
+        Object argument = new String[]{"hello", null};
+        writeRead(new Object[]{argument});
+        String[] s = writeRead(new Object[]{argument});
+        Assert.assertArrayEquals(new String[]{"[hello, null]"}, s);
+    }
+
+    @Test
+    public void writeIntArrayArgument() throws IOException {
+        Object argument = new int[]{8, 99, 77};
+        String[] s = writeRead(new Object[]{argument});
+        Assert.assertArrayEquals(new String[]{"[8, 99, 77]"}, s);
+    }
+
+    @Test
+    public void writeIntDoubleArrayArgument() throws IOException {
+        Object argument = new int[][]{{8}, {99, 7}, {}};
+        String[] s = writeRead(new Object[]{argument});
+        Assert.assertArrayEquals(new String[]{"[[8], [99, 7], []]"}, s);
+    }
+
+    @Test(timeout = 500)
+    public void writeObjectArraySelfReference() throws IOException {
+        Object[] argument = new Object[]{"hello", "world"};
+        argument[1] = argument;
+        String[] s = writeRead(new Object[]{argument});
+        Assert.assertArrayEquals(new String[]{"[hello, [...]]"}, s);
+    }
+
+    @Test
+    public void writeMultiArrayArguments() throws IOException {
+        int[] argument0 = new int[]{8, 99, 77};
+        int[] argument1 = new int[]{7, -2};
+        String[] s = writeRead(new Object[]{argument0, argument1});
+        Assert.assertArrayEquals(new String[]{"[8, 99, 77]", "[7, -2]"}, s);
+    }
+
+    private String[] writeRead(Object[] args) throws IOException {
+        File source = folder.newFile();
+        File outputDir = folder.newFolder();
+        FileArgumentsWriter writer = new FileArgumentsWriter(outputDir);
+        writer.write(args, source);
+        return Arrays.stream(Objects.requireNonNull(outputDir.listFiles())).sorted()
+                     .map(FileArgumentsWriterTest::readString).toArray(String[]::new);
+    }
+
+    private static String readString(File file) {
+        try {
+            byte[] encoded = Files.readAllBytes(file.toPath());
+            return new String(encoded, StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new AssertionError(e);
+        }
+    }
+}


### PR DESCRIPTION
**Discription of PR**
Currently the parameterized junit4 branch only outputs an address for arrays, which is not helpful for debugging. This PR instead prints the content of an array. If the content of an array is also array, this PR also adds support for outputing them recursively. This PR also changes the output formats to recursive folders, i.e., `$argFile/$indexOfArg/$indexInArray/...`

**For Code Changes:**
A new function `observeGeneratedArgs` is added so as to 'decompress' the arrays and output the elements recursively. A `maxRecurDepth` is also added to prevent stack overflow caused by too many layers of recursion.

The change has been tested on small maven projects.