### PR TITLE
Improved failure report

### DIFF
--- a/meringue-core/src/main/java/edu/neu/ccs/prl/meringue/Failure.java
+++ b/meringue-core/src/main/java/edu/neu/ccs/prl/meringue/Failure.java
@@ -10,10 +10,20 @@ public final class Failure implements Serializable {
     private final String type;
     private final List<StackTraceElement> trace;
 
-    public Failure(Throwable failure, StackTraceCleaner cleaner) {
-        this.type = failure.getClass().getName();
-        this.trace = Collections.unmodifiableList(Arrays.asList(cleaner.cleanStackTrace(failure)
-                                                                       .toArray(new StackTraceElement[0])));
+    public Failure(String type, StackTraceElement[] trace) {
+        if (type == null) {
+            throw new NullPointerException();
+        }
+        this.type = type;
+        this.trace = Collections.unmodifiableList(Arrays.asList(trace));
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public List<StackTraceElement> getTrace() {
+        return trace;
     }
 
     @Override

--- a/meringue-core/src/main/java/edu/neu/ccs/prl/meringue/ReplayerManager.java
+++ b/meringue-core/src/main/java/edu/neu/ccs/prl/meringue/ReplayerManager.java
@@ -35,24 +35,15 @@ public final class ReplayerManager implements Closeable {
         // Send current JaCoCo coverage
         connection.send(RT.getAgent().getExecutionData(false));
         // Send the failure
-        Failure wrappedFailure = wrap(failure);
-        if (wrappedFailure == null) {
+        if (failure == null) {
             connection.send(false);
         } else {
+            Throwable rootCause = cleaner.getRootCause(failure);
+            StackTraceElement[] trace = cleaner.cleanStackTrace(rootCause).toArray(new StackTraceElement[0]);
             connection.send(true);
-            connection.send(wrappedFailure);
+            connection.send(new Failure(rootCause.getClass().getName(), trace));
+            connection.send(rootCause.getMessage());
         }
-    }
-
-    private Failure wrap(Throwable failure) {
-        if (failure != null) {
-            try {
-                return new Failure(failure, cleaner);
-            } catch (Throwable t) {
-                // This hopefully should not happen but there is not much we can do about it
-            }
-        }
-        return null;
     }
 
     @Override

--- a/meringue-core/src/main/java/edu/neu/ccs/prl/meringue/StackTraceCleaner.java
+++ b/meringue-core/src/main/java/edu/neu/ccs/prl/meringue/StackTraceCleaner.java
@@ -6,8 +6,8 @@ import java.util.function.Predicate;
 
 /**
  * Produces cleaned stack traces. A cleaned stack trace is created by first identifying the root cause of an exception
- * or error. Internal frames are removed from the stack trace for the root cause.
- * Finally, the root cause trace is trimmed to a specified maximum number of elements.
+ * or error. Internal frames are removed from the stack trace for the root cause. Finally, the root cause trace is
+ * trimmed to a specified maximum number of elements.
  */
 public class StackTraceCleaner {
     private final int maxSize;
@@ -29,9 +29,7 @@ public class StackTraceCleaner {
     }
 
     public List<StackTraceElement> cleanStackTrace(Throwable t) {
-        while (t.getCause() != null) {
-            t = t.getCause();
-        }
+        t = getRootCause(t);
         List<StackTraceElement> cleanedTrace = new LinkedList<>();
         for (StackTraceElement element : t.getStackTrace()) {
             if (cleanedTrace.size() == maxSize) {
@@ -42,5 +40,12 @@ public class StackTraceCleaner {
             }
         }
         return cleanedTrace;
+    }
+
+    public Throwable getRootCause(Throwable t) {
+        while (t.getCause() != null) {
+            t = t.getCause();
+        }
+        return t;
     }
 }

--- a/meringue-maven-plugin/src/main/java/edu/neu/ccs/prl/meringue/CampaignAnalyzer.java
+++ b/meringue-maven-plugin/src/main/java/edu/neu/ccs/prl/meringue/CampaignAnalyzer.java
@@ -56,11 +56,16 @@ final class CampaignAnalyzer implements Closeable {
         try {
             connection.send(inputFile);
             byte[] execData = connection.receive(byte[].class);
-            Failure failure = connection.receive(Boolean.class) ? connection.receive(Failure.class) : null;
+            Failure failure = null;
+            String failureMessage = null;
+            if (connection.receive(Boolean.class)) {
+                failure = connection.receive(Failure.class);
+                failureMessage = connection.receive(String.class);
+            }
             if (timer != null) {
                 timer.cancel();
             }
-            failureReport.record(inputFile, failure);
+            failureReport.record(inputFile, failure, failureMessage);
             coverageReport.record(inputFile, execData);
         } catch (Throwable t) {
             // Input caused fork to fail

--- a/meringue-maven-plugin/src/main/java/edu/neu/ccs/prl/meringue/report/FailureReport.java
+++ b/meringue-maven-plugin/src/main/java/edu/neu/ccs/prl/meringue/report/FailureReport.java
@@ -17,11 +17,11 @@ public final class FailureReport {
         this.firstTimestamp = firstTimestamp;
     }
 
-    public void record(File inputFile, Failure failure) {
+    public void record(File inputFile, Failure failure, String failureMessage) {
         if (failure != null) {
             long time = inputFile.lastModified() - firstTimestamp;
             if (!failureMap.containsKey(failure)) {
-                failureMap.put(failure, new FailureEntry(time, failure));
+                failureMap.put(failure, new FailureEntry(failure, time, failureMessage));
             }
             failureMap.get(failure).inducingInputs.add(inputFile);
         }
@@ -40,13 +40,15 @@ public final class FailureReport {
      */
     @SuppressWarnings({"unused", "FieldCanBeLocal", "MismatchedQueryAndUpdateOfCollection"})
     private static final class FailureEntry {
-        private final long time;
         private final Failure failure;
+        private final long firstTime;
+        private final String firstMessage;
         private final List<File> inducingInputs = new LinkedList<>();
 
-        private FailureEntry(long time, Failure failure) {
-            this.time = time;
+        private FailureEntry(Failure failure, long firstTime, String firstMessage) {
+            this.firstTime = firstTime;
             this.failure = failure;
+            this.firstMessage = firstMessage;
         }
     }
 }


### PR DESCRIPTION
* Fixed bug where the type used for failure report entries was for the original failure not the root cause
* Renamed failure report entry field "time" to "firstTime"
* Added the field "firstMessage" to failure report entries to capture the description message of the root cause of the failure for the first input that induced that failure


Resolves #4 