### PR TITLE
Improved coverage reporting

### DIFF
--- a/meringue-maven-plugin/src/main/java/edu/neu/ccs/prl/meringue/AnalysisMojo.java
+++ b/meringue-maven-plugin/src/main/java/edu/neu/ccs/prl/meringue/AnalysisMojo.java
@@ -21,14 +21,14 @@ public class AnalysisMojo extends AbstractMeringueMojo implements AnalysisValues
     @Parameter(property = "meringue.includedArtifacts")
     List<String> includedArtifacts = new LinkedList<>();
     /**
-     * List of class files to include in JaCoCo reports. May use wildcard characters (* and ?). By default, all files
-     * are included.
+     * List of class files to include in coverage and JaCoCo reports. May use wildcard characters (* and ?). By default,
+     * all files are included.
      */
     @Parameter(property = "meringue.inclusions")
     private List<String> inclusions = new LinkedList<>();
     /**
-     * List of class files to exclude from JaCoCo reports. May use wildcard characters (* and ?). By default, no files
-     * are excluded.
+     * List of class files to exclude from coverage and JaCoCo reports. May use wildcard characters (* and ?). By
+     * default, no files are excluded.
      */
     @Parameter(property = "meringue.exclusions")
     private List<String> exclusions = new LinkedList<>();
@@ -61,6 +61,11 @@ public class AnalysisMojo extends AbstractMeringueMojo implements AnalysisValues
      */
     @Parameter(property = "meringue.jacocoFormats", defaultValue = "HTML,CSV,XML")
     private List<JacocoReportFormat> jacocoFormats;
+    /**
+     * True if classes from the Java Class Library should be included in coverage and JaCoCo reports.
+     */
+    @Parameter(property = "meringue.includeJavaClassLibrary", defaultValue = "false")
+    private boolean includeJavaClassLibrary;
     @Component
     private ArtifactResolver artifactResolver;
     @Component
@@ -119,5 +124,10 @@ public class AnalysisMojo extends AbstractMeringueMojo implements AnalysisValues
     @Override
     public ArtifactHandlerManager getArtifactHandlerManager() {
         return artifactHandlerManager;
+    }
+
+    @Override
+    public boolean includeJavaClassLibrary() {
+        return includeJavaClassLibrary;
     }
 }

--- a/meringue-maven-plugin/src/main/java/edu/neu/ccs/prl/meringue/AnalysisValues.java
+++ b/meringue-maven-plugin/src/main/java/edu/neu/ccs/prl/meringue/AnalysisValues.java
@@ -23,14 +23,14 @@ public interface AnalysisValues extends CampaignValues {
     List<String> getIncludedArtifacts() throws MojoExecutionException;
 
     /**
-     * List of class files to include in JaCoCo reports. May use wildcard characters (* and ?). If empty, all files are
-     * included.
+     * List of class files to include in coverage and JaCoCo reports. May use wildcard characters (* and ?). If empty,
+     * all files are included.
      */
     List<String> getInclusions() throws MojoExecutionException;
 
     /**
-     * List of class files to exclude from JaCoCo reports. May use wildcard characters (* and ?). If empty, no files are
-     * excluded.
+     * List of class files to exclude from coverage and JaCoCo reports. May use wildcard characters (* and ?). If empty,
+     * no files are excluded.
      */
     List<String> getExclusions() throws MojoExecutionException;
 
@@ -77,12 +77,20 @@ public interface AnalysisValues extends CampaignValues {
 
     default CoverageCalculator createCoverageCalculator() throws MojoExecutionException {
         try {
-            return new CoverageFilter(getInclusions(), getExclusions(), getIncludedArtifacts(), getProject(),
-                                      createArtifactSourceResolver())
+            return new CoverageFilter(this)
                     .createCoverageCalculator(getTemporaryDirectory());
         } catch (IOException e) {
             throw new MojoExecutionException("Failed to create coverage calculator", e);
         }
+    }
+
+    /**
+     * True if classes from the Java Class Library should be included in coverage and JaCoCo reports.
+     *
+     * @return true if classes from the Java Class Library should be included in coverage and JaCoCo reports.
+     */
+    default boolean includeJavaClassLibrary() {
+        return false;
     }
 
     default void analyze() throws MojoExecutionException {

--- a/meringue-maven-plugin/src/main/java/edu/neu/ccs/prl/meringue/ClassFilter.java
+++ b/meringue-maven-plugin/src/main/java/edu/neu/ccs/prl/meringue/ClassFilter.java
@@ -1,6 +1,7 @@
 package edu.neu.ccs.prl.meringue;
 
 import org.apache.maven.artifact.Artifact;
+import org.apache.maven.plugin.MojoExecutionException;
 
 import java.util.*;
 
@@ -21,6 +22,10 @@ public final class ClassFilter {
         this.includedArtifacts =
                 includedArtifacts == null ? Collections.emptySet() :
                         Collections.unmodifiableSet(new HashSet<>(includedArtifacts));
+    }
+
+    public ClassFilter(AnalysisValues values) throws MojoExecutionException {
+        this(values.getInclusions(), values.getExclusions(), values.getIncludedArtifacts());
     }
 
     public String getExcludeString() {

--- a/meringue-maven-plugin/src/main/java/edu/neu/ccs/prl/meringue/JacocoReportFormat.java
+++ b/meringue-maven-plugin/src/main/java/edu/neu/ccs/prl/meringue/JacocoReportFormat.java
@@ -11,24 +11,34 @@ import java.io.IOException;
 import java.nio.file.Files;
 
 public enum JacocoReportFormat {
-    HTML() {
+    HTML(true) {
         @Override
         public IReportVisitor createVisitor(File outputDirectory) throws IOException {
             return new HTMLFormatter().createVisitor(new FileMultiReportOutput(new File(outputDirectory, "html")));
         }
-    }, CSV() {
+    }, CSV(false) {
         @Override
         public IReportVisitor createVisitor(File outputDirectory) throws IOException {
             return new CSVFormatter().createVisitor(
                     Files.newOutputStream(new File(outputDirectory, "jacoco.csv").toPath()));
         }
-    }, XML() {
+    }, XML(false) {
         @Override
         public IReportVisitor createVisitor(File outputDirectory) throws IOException {
             return new XMLFormatter().createVisitor(
                     Files.newOutputStream(new File(outputDirectory, "jacoco.xml").toPath()));
         }
     };
+
+    private final boolean includeSources;
+
+    JacocoReportFormat(boolean requiresSources) {
+        this.includeSources = requiresSources;
+    }
+
+    public boolean shouldIncludeSources() {
+        return includeSources;
+    }
 
     public abstract IReportVisitor createVisitor(File outputDirectory) throws IOException;
 }

--- a/meringue-maven-plugin/src/main/java/edu/neu/ccs/prl/meringue/report/CoverageReport.java
+++ b/meringue-maven-plugin/src/main/java/edu/neu/ccs/prl/meringue/report/CoverageReport.java
@@ -40,8 +40,7 @@ public final class CoverageReport {
     public void writeJacocoReports(String testDescription, File directory, Iterable<JacocoReportFormat> formats)
             throws IOException {
         for (JacocoReportFormat format : formats) {
-            calculator.createReport(lastExecData == null ? new byte[0] : lastExecData, testDescription,
-                                    format.createVisitor(directory));
+            calculator.createReport(lastExecData, testDescription, format, directory);
         }
     }
 


### PR DESCRIPTION
* Added option to include classes from the Java Class Library in coverage and JaCoCo reports.
* Fixed bug with sources not be used in JaCoCo reports if the source was already extracted from an archive
* Prevented sources from being downloaded and extracted for XML and CSV JaCoCo reports