### PR TITLE
update jazzer to 0.21.1

### DIFF
--- a/meringue-jazzer-extension/pom.xml
+++ b/meringue-jazzer-extension/pom.xml
@@ -12,12 +12,12 @@
     <name>meringue-jazzer-extension</name>
     <packaging>jar</packaging>
     <properties>
-        <jazzer.version>0.11.0</jazzer.version>
+        <jazzer.version>0.21.1</jazzer.version>
         <jazzer.linux.url>
-            https://github.com/CodeIntelligenceTesting/jazzer/releases/download/v${jazzer.version}/jazzer-linux-${jazzer.version}.tar.gz
+            https://github.com/CodeIntelligenceTesting/jazzer/releases/download/v${jazzer.version}/jazzer-linux.tar.gz
         </jazzer.linux.url>
         <jazzer.mac.url>
-            https://github.com/CodeIntelligenceTesting/jazzer/releases/download/v${jazzer.version}/jazzer-macos-${jazzer.version}.tar.gz
+            https://github.com/CodeIntelligenceTesting/jazzer/releases/download/v${jazzer.version}/jazzer-macos.tar.gz
         </jazzer.mac.url>
     </properties>
     <dependencies>

--- a/meringue-jazzer-extension/src/main/java/edu/neu/ccs/prl/meringue/JazzerFramework.java
+++ b/meringue-jazzer-extension/src/main/java/edu/neu/ccs/prl/meringue/JazzerFramework.java
@@ -131,7 +131,7 @@ public final class JazzerFramework implements FuzzFramework {
         } else {
             throw new IllegalStateException("Operating system not supported");
         }
-        String[] resourceNames = new String[]{"jazzer_agent_deploy.jar", "jazzer_api_deploy.jar", executableName};
+        String[] resourceNames = new String[]{"jazzer_standalone.jar", executableName};
         File bin = new File(outputDir, "bin");
         FileUtil.ensureDirectory(bin);
         File jazzerExec = new File(bin, executableName);


### PR DESCRIPTION
jazzer merged `jazzer_agent_deploy` and `jazzer_api_deploy` into `jazzer_standalone` sometime in [v0.14.0](https://github.com/CodeIntelligenceTesting/jazzer/releases/tag/v0.14.0). I'm not sure exactly what commit. Maybe https://github.com/CodeIntelligenceTesting/jazzer/commit/752875c3de6365aad8c590cb6170b40422217fe2.

I very briefly tested this with a one-minute fuzz of the example maven fuzz target:

```
mvn -fmeringue-examples -Dmeringue.duration=PT1M -Pjazzer,maven verify
```

and eyeballed the before and after coverage reports just to make sure nothing major broke.