### PR TITLE
Fix plugin crash if the class version is not supported.

### DIFF
--- a/meringue-maven-plugin/src/main/java/edu/neu/ccs/prl/meringue/CoverageCalculator.java
+++ b/meringue-maven-plugin/src/main/java/edu/neu/ccs/prl/meringue/CoverageCalculator.java
@@ -177,7 +177,7 @@ public class CoverageCalculator {
         public void analyzeClass(final byte[] buffer, final String location) {
             try {
                 super.analyzeClass(buffer, location);
-            } catch (IOException e) {
+            } catch (IOException | IllegalArgumentException e) {
                 // Suppress the exception so that other classes are still analyzed
             }
         }
@@ -189,7 +189,7 @@ public class CoverageCalculator {
             } else {
                 try (InputStream in = Files.newInputStream(file.toPath())) {
                     return analyzeAll(in, file.getPath());
-                } catch (IOException e) {
+                } catch (IOException | IllegalArgumentException e) {
                     // Suppress the exception so that other classes are still analyzed
                     return 0;
                 }


### PR DESCRIPTION
The maven plugin crashes if JaCoCo and ASM do not support the class version. In that case, ASM throws `IllegalArgumentException`. Adding this exception to the catch block to prevent the plugin from crashing. 

https://gitlab.ow2.org/asm/asm/-/blob/master/asm/src/main/java/org/objectweb/asm/ClassReader.java#L199