### PR TITLE
Avoid concurrent modification while running meringue in parallel.

### DIFF
--- a/meringue-maven-plugin/src/main/java/edu/neu/ccs/prl/meringue/AbstractMeringueMojo.java
+++ b/meringue-maven-plugin/src/main/java/edu/neu/ccs/prl/meringue/AbstractMeringueMojo.java
@@ -86,7 +86,7 @@ abstract class AbstractMeringueMojo extends AbstractMojo implements CampaignValu
     private ArtifactHandlerManager artifactHandlerManager;
     /**
      * Temporary directory unique to this instance.
-     * Ensures that different executions of the plugin write to different directories. 
+     * Ensures that different executions of the plugin write to different directories.
      */
     private File temporaryDirectoryPerInstance;
 

--- a/meringue-maven-plugin/src/main/java/edu/neu/ccs/prl/meringue/AbstractMeringueMojo.java
+++ b/meringue-maven-plugin/src/main/java/edu/neu/ccs/prl/meringue/AbstractMeringueMojo.java
@@ -148,7 +148,7 @@ abstract class AbstractMeringueMojo extends AbstractMojo implements CampaignValu
             try {
                 temporaryDirectoryPerInstance = Files.createTempDirectory(temporaryDirectory.toPath(), "meringue-").toFile();
             } catch (IOException e) {
-                throw new RuntimeException(e);
+                throw new MojoExecutionException("Failed to create temporary directory", e);
             }
         }
         return temporaryDirectoryPerInstance;

--- a/meringue-maven-plugin/src/main/java/edu/neu/ccs/prl/meringue/AbstractMeringueMojo.java
+++ b/meringue-maven-plugin/src/main/java/edu/neu/ccs/prl/meringue/AbstractMeringueMojo.java
@@ -84,6 +84,10 @@ abstract class AbstractMeringueMojo extends AbstractMojo implements CampaignValu
     private RepositorySystem repositorySystem;
     @Component
     private ArtifactHandlerManager artifactHandlerManager;
+    /**
+     * Temporary directory unique to this instance.
+     * Ensures that different executions of the plugin write to different directories. 
+     */
     private File temporaryDirectoryPerInstance;
 
     @Override

--- a/meringue-maven-plugin/src/main/java/edu/neu/ccs/prl/meringue/AbstractMeringueMojo.java
+++ b/meringue-maven-plugin/src/main/java/edu/neu/ccs/prl/meringue/AbstractMeringueMojo.java
@@ -13,6 +13,8 @@ import org.apache.maven.project.MavenProject;
 import org.apache.maven.repository.RepositorySystem;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.util.*;
 
 abstract class AbstractMeringueMojo extends AbstractMojo implements CampaignValues {
@@ -82,6 +84,7 @@ abstract class AbstractMeringueMojo extends AbstractMojo implements CampaignValu
     private RepositorySystem repositorySystem;
     @Component
     private ArtifactHandlerManager artifactHandlerManager;
+    private File temporaryDirectoryPerInstance;
 
     @Override
     public MavenSession getSession() throws MojoExecutionException {
@@ -141,7 +144,14 @@ abstract class AbstractMeringueMojo extends AbstractMojo implements CampaignValu
 
     @Override
     public File getTemporaryDirectory() throws MojoExecutionException {
-        return temporaryDirectory;
+        if (temporaryDirectoryPerInstance == null) {
+            try {
+                temporaryDirectoryPerInstance = Files.createTempDirectory(temporaryDirectory.toPath(), "meringue-").toFile();
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return temporaryDirectoryPerInstance;
     }
 
     @Override


### PR DESCRIPTION
If I run multiple meringue instances in parallel, they will all try to modify `target/temp/meringue` folder together. This PR fixes the issue by creating a separate run folder for each instance. 