### PR TITLE
Fix meringue crash if `temporaryDirectory` does not exist.

### DIFF
--- a/meringue-maven-plugin/src/main/java/edu/neu/ccs/prl/meringue/AbstractMeringueMojo.java
+++ b/meringue-maven-plugin/src/main/java/edu/neu/ccs/prl/meringue/AbstractMeringueMojo.java
@@ -150,6 +150,11 @@ abstract class AbstractMeringueMojo extends AbstractMojo implements CampaignValu
     public File getTemporaryDirectory() throws MojoExecutionException {
         if (temporaryDirectoryPerInstance == null) {
             try {
+                if (!temporaryDirectory.exists()) {
+                    if (!temporaryDirectory.mkdirs()) {
+                        throw new MojoExecutionException("Failed to create temporary directory");
+                    }
+                }
                 temporaryDirectoryPerInstance = Files.createTempDirectory(temporaryDirectory.toPath(), "meringue-").toFile();
             } catch (IOException e) {
                 throw new MojoExecutionException("Failed to create temporary directory", e);


### PR DESCRIPTION
#9 Introduced a crash if `temporaryDirectory` does not exist. This prevents meringue from being used in a fresh cloned repo where `target/temp/meringue` is not created.